### PR TITLE
Made compatible with the "latest as of now" WooCommerce Customer/Orde…

### DIFF
--- a/php/class-csv-export.php
+++ b/php/class-csv-export.php
@@ -97,7 +97,7 @@ class CSV_Export {
 	 */
 	public function wc_csv_export_modify_row_data( $order_data, $order, $csv_generator ) {
 		// Get the post meta containing the Gift Aid status.
-		$status = get_post_meta( $order->id, 'gift_aid_reclaimed', true );
+		$status = get_post_meta( $order->get_id(), 'gift_aid_reclaimed', true );
 
 		// Add a fallback of "No" if no source is available.
 		$status = ( ! empty( $status ) ? $status : __( 'No', 'gift-aid-for-woocommerce' ) );

--- a/php/class-csv-export.php
+++ b/php/class-csv-export.php
@@ -109,9 +109,16 @@ class CSV_Export {
 
 		// Merge our data with the existing row data.
 		$new_order_data = array();
+		$one_row_per_item = false;
 
-		if ( isset( $csv_generator->order_format ) && ( 'default_one_row_per_item' == $csv_generator->order_format || 'legacy_one_row_per_item' == $csv_generator->order_format ) ) {
-
+		if ( version_compare( wc_customer_order_csv_export()->get_version(), '4.0.0', '<' ) ) {
+			// pre 4.0 compatibility
+			$one_row_per_item = ( 'default_one_row_per_item' === $csv_generator->order_format || 'legacy_one_row_per_item' === $csv_generator->order_format );
+		} elseif ( isset( $csv_generator->format_definition ) ) {
+			// post 4.0 (requires 4.0.3+)
+			$one_row_per_item = 'item' === $csv_generator->format_definition['row_type'];
+		}
+		if ( $one_row_per_item ) {
 			foreach ( $order_data as $data ) {
 				$new_order_data[] = array_merge( (array) $data, $custom_data );
 			}

--- a/php/class-orders.php
+++ b/php/class-orders.php
@@ -131,7 +131,7 @@ class Orders {
 	 */
 	public function add_order_details( $order ) {
 		// Get the post meta containing the Gift Aid status.
-		$status = get_post_meta( $order->id, 'gift_aid_reclaimed', true );
+		$status = get_post_meta( $order->get_id(), 'gift_aid_reclaimed', true );
 
 		// Add a fallback of "No" if no source is available.
 		$status = ( ! empty( $status ) ? $status : __( 'No', 'gift-aid-for-woocommerce' ) );
@@ -156,7 +156,7 @@ class Orders {
 	public function add_order_email_meta( $order, $sent_to_admin, $plain_text ) {
 
 		// Get the post meta containing the Gift Aid status.
-		$status = get_post_meta( $order->id, 'gift_aid_reclaimed', true );
+		$status = get_post_meta( $order->get_id(), 'gift_aid_reclaimed', true );
 
 		if ( ! $sent_to_admin ) {
 			// Set our confirmation message for the customer.


### PR DESCRIPTION
Made compatible with the latest WooCommerce Customer/Order CSV Export Version (as of now it's 4.5.2).

Currently, when exporting to CSV and **single line item** is set under Custom Formats tab, **reclaim_gift_aid** is empty, also it creates an unnecessary new row at the end of the CSV too - this could break fulfilment processes.